### PR TITLE
Feat/EZSMS-998 add requests cache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,8 @@ setuptools.setup(
     ],
     packages=setuptools.find_packages(),
     python_requires=">=3.6",
+    install_requires=[
+        'requests',
+        'requests-cache'
+    ],
 )

--- a/wpyblog/views.py
+++ b/wpyblog/views.py
@@ -21,7 +21,7 @@ WPYBLOG_REQUESTS_CACHE_ENABLE = settings.__dict__.get('WPYBLOG_REQUESTS_CACHE_EN
 cache_key = settings.__dict__.get('WPYBLOG_CACHE', 'wpyblog_cache')
 
 if WPYBLOG_REQUESTS_CACHE_ENABLE:
-    requests_cache.install_cache(f'wpyblog_cache')
+    requests_cache.install_cache(cache_key)
 
 
 @cache_page(ONE_DAY)

--- a/wpyblog/views.py
+++ b/wpyblog/views.py
@@ -18,10 +18,9 @@ ONE_WEEK = ONE_DAY * 7
 timeout = settings.__dict__.get('BLOG_TIMEOUT', 5)
 
 WPYBLOG_REQUESTS_CACHE_ENABLE = settings.__dict__.get('WPYBLOG_REQUESTS_CACHE_ENABLE', True)
-cache_key = settings.__dict__.get('WPYBLOG_CACHE')
 
 if WPYBLOG_REQUESTS_CACHE_ENABLE:
-    requests_cache.install_cache(cache_key)
+    requests_cache.install_cache()
 
 
 @cache_page(ONE_DAY)

--- a/wpyblog/views.py
+++ b/wpyblog/views.py
@@ -8,7 +8,7 @@ from django.utils.encoding import uri_to_iri
 from django.utils import translation
 
 import requests
-import requests_cache
+from requests_cache import CachedSession
 
 ONE_HOUR = 60 * 60
 HALF_DAY = ONE_HOUR * 12
@@ -20,7 +20,7 @@ timeout = settings.__dict__.get('BLOG_TIMEOUT', 5)
 WPYBLOG_REQUESTS_CACHE_ENABLE = settings.__dict__.get('WPYBLOG_REQUESTS_CACHE_ENABLE', True)
 
 if WPYBLOG_REQUESTS_CACHE_ENABLE:
-    requests_cache.install_cache()
+    requests = CachedSession(expire_after=ONE_WEEK)
 
 
 @cache_page(ONE_DAY)
@@ -207,4 +207,8 @@ def get_blog_access():
 
 def clear_cache(request):
     cache.clear()
+
+    if WPYBLOG_REQUESTS_CACHE_ENABLE:
+        requests.cache.clear()
+
     return HttpResponse('blog cache cleared!')

--- a/wpyblog/views.py
+++ b/wpyblog/views.py
@@ -8,6 +8,7 @@ from django.utils.encoding import uri_to_iri
 from django.utils import translation
 
 import requests
+import requests_cache
 
 ONE_HOUR = 60 * 60
 HALF_DAY = ONE_HOUR * 12
@@ -15,6 +16,13 @@ ONE_DAY = ONE_HOUR * 24
 ONE_WEEK = ONE_DAY * 7
 
 timeout = settings.__dict__.get('BLOG_TIMEOUT', 5)
+
+WPYBLOG_REQUESTS_CACHE_ENABLE = settings.__dict__.get('WPYBLOG_REQUESTS_CACHE_ENABLE', True)
+cache_key = settings.__dict__.get('WPYBLOG_CACHE', 'wpyblog_cache')
+
+if WPYBLOG_REQUESTS_CACHE_ENABLE:
+    requests_cache.install_cache(f'wpyblog_cache')
+
 
 @cache_page(ONE_DAY)
 def list_post(request):

--- a/wpyblog/views.py
+++ b/wpyblog/views.py
@@ -15,7 +15,7 @@ HALF_DAY = ONE_HOUR * 12
 ONE_DAY = ONE_HOUR * 24
 ONE_WEEK = ONE_DAY * 7
 
-timeout = settings.__dict__.get('BLOG_TIMEOUT', 5)
+timeout = settings.__dict__.get('BLOG_TIMEOUT', 7)
 
 WPYBLOG_REQUESTS_CACHE_ENABLE = settings.__dict__.get('WPYBLOG_REQUESTS_CACHE_ENABLE', True)
 

--- a/wpyblog/views.py
+++ b/wpyblog/views.py
@@ -18,7 +18,7 @@ ONE_WEEK = ONE_DAY * 7
 timeout = settings.__dict__.get('BLOG_TIMEOUT', 5)
 
 WPYBLOG_REQUESTS_CACHE_ENABLE = settings.__dict__.get('WPYBLOG_REQUESTS_CACHE_ENABLE', True)
-cache_key = settings.__dict__.get('WPYBLOG_CACHE', 'wpyblog_cache')
+cache_key = settings.__dict__.get('WPYBLOG_CACHE')
 
 if WPYBLOG_REQUESTS_CACHE_ENABLE:
     requests_cache.install_cache(cache_key)


### PR DESCRIPTION
# Chache external API using requests-cache

- [x] add new caching method `requests-cache`: save the cache to `.sqlite`
- [x] change timeout request from WP sources: 5s to 7s

## Description `requests-cache`
- Purpose: to make a better performance EZsms blog. 
- By default, it will create a `.sqlite` file. So, need to add `.sqlite` inside .gitignore
<img width="185" alt="Screenshot 2023-05-04 at 21 06 56" src="https://user-images.githubusercontent.com/23071425/236233202-8f3118d7-51b7-4b2a-8b94-2acbcaf2951d.png"> 

- Has several backend cache methods, such as .sqlite, memory, etc. In this PR using `.sqlite`:
https://requests-cache.readthedocs.io/en/stable/user_guide/backends.html#backends
    *`.sqlite` save data on disk (file system), so it's not taken so much (or even any?) memory
https://www.sqlite.org/whentouse.html
- In this PR cache expire is set to `ONE_WEEK`

## Test result:
![Screenshot 2023-05-04 at 21 16 10](https://user-images.githubusercontent.com/23071425/236235334-f44472af-6fed-4928-a35c-371f74cee044.png)

## References:
- https://requests-cache.readthedocs.io/en/stable/index.html
- https://stackoverflow.com/questions/60899696/cache-response-in-python
- https://requests-cache.readthedocs.io/en/stable/user_guide/backends.html#backends
- https://realpython.com/caching-external-api-requests/
